### PR TITLE
Installation: Front-end Doesn't Require Postgres

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,6 @@ The following instructions assume Ubuntu or Debian hosts:
 
 .. code:: bash
 
-    $ aptitude install postgresql-9.4
     $ git clone https://github.com/thegroovebox/groovebox.org.git
     $ cd groovebox.org/
     $ pip3 install -e .


### PR DESCRIPTION
At least at this point, front-end is Flask templating plus static asset serving. No need for requiring presence of PostgreSQL.
