### PR TITLE
installation: typo for compiling sass cmd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ The following instructions assume Ubuntu or Debian hosts:
     $ pip3 install -e .
     $ cd groovebox/static
     $ npm install .
-    $ npm styles # rebuild sass -> css
+    $ ./node_modules/.bin/gulp styles # rebuild sass -> css
     $ cd ..
     $ python3.4 app.py # run the app
 


### PR DESCRIPTION
'npm styles' doesn't do anything; 'gulp styles' is likely the command intended.

additionally, since your instructions doesn't guarantee gulp available globally, use bin script present in the installed node_modules after 'npm install .' command.
