### PR TITLE
add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    python3-pip
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+RUN apt-get install -y nodejs
+WORKDIR /root/
+RUN git clone https://github.com/thegroovebox/groovebox.org.git
+WORKDIR /root/groovebox.org/
+RUN pip3 install -e .
+WORKDIR /root/groovebox.org/groovebox/static/
+RUN npm install .
+RUN ./node_modules/.bin/gulp styles
+WORKDIR /root/groovebox.org/groovebox/
+EXPOSE 8080
+CMD python3 app.py


### PR DESCRIPTION
works on my VPS and VMs.

doesn't enable/disable debug flags for building or running app.py. thus, the default build will not have css minified, and will leave the flask debugger active. not sure how to fix this (beyond scope of the Dockerfile really); maybe include a default settings.cfg in the repo? and/or have the build scripts and app.py config check for an environment flag?
